### PR TITLE
Sync Meltano(tempo) connection failed with caching error.

### DIFF
--- a/prefect_meltano/sink_wrapper.py
+++ b/prefect_meltano/sink_wrapper.py
@@ -6,6 +6,7 @@ import tempfile
 from typing import Any, Dict, Optional, Type, Union, IO
 
 from prefect import task
+from prefect.cache_policies import NO_CACHE
 from singer_sdk import Target
 
 from prefect_meltano.utils import resolve_class
@@ -136,7 +137,7 @@ def run_singer_target_from_file(
     )
 
 
-@task(name="run_singer_target_from_file_task", description="Run singer target reading from a file-like input")
+@task(name="run_singer_target_from_file_task", description="Run singer target reading from a file-like input", cache_policy=NO_CACHE)
 async def run_singer_target_task(*args, **kwargs) -> SingerTargetResult:
     """
     Async Prefect task wrapper that executes run_singer_target_from_file in a thread.

--- a/prefect_meltano/tap_wrapper.py
+++ b/prefect_meltano/tap_wrapper.py
@@ -8,6 +8,7 @@ from contextlib import redirect_stdout, redirect_stderr
 from typing import Any, Dict, Optional, Type, Union
 
 from prefect import task
+from prefect.cache_policies import NO_CACHE
 from singer_sdk import Tap
 
 from prefect_meltano.utils import resolve_class
@@ -195,7 +196,7 @@ def run_singer_tap(
     )
 
 
-@task(name="run_singer_tap_task", description="Execute run_singer_tap as an async Prefect task")
+@task(name="run_singer_tap_task", description="Execute run_singer_tap as an async Prefect task", cache_policy=NO_CACHE)
 async def run_singer_tap_task(*args, **kwargs) -> SingerTapResult:
     """
     Async Prefect task wrapper around run_singer_tap.


### PR DESCRIPTION
1. fix cache problems with non-serializable objects.
